### PR TITLE
CI: omnipay doesn't have a master branch any more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ jobs:
     with:
       composer_require_extra:
         phpunit/phpunit:^9.5
-        silverstripe/silverstripe-omnipay:dev-master
+        silverstripe/silverstripe-omnipay:dev-main
         php-http/discovery:^1.18.1


### PR DESCRIPTION
CI was failing, cause it's trying to install silverstripe-omnipay:dev-master, which doesn't exist any more. It was renamed to dev-main